### PR TITLE
[dbus-stream]feat: 分表情况下支持增量数据合并

### DIFF
--- a/dbus-stream/dbus-stream-common/src/main/java/com/creditease/dbus/stream/common/appender/utils/DBFacade.java
+++ b/dbus-stream/dbus-stream-common/src/main/java/com/creditease/dbus/stream/common/appender/utils/DBFacade.java
@@ -967,6 +967,10 @@ public class DBFacade {
 
     public MetaVersion queryMetaVersion(long dsId, String schemaName, String tableName) {
         DataTable tab = queryDataTable(dsId, schemaName, tableName);
+        if (tab == null) {
+            logger.warn("Can not find data table schema: {}, table: {}", schemaName, tableName);
+            return  null;
+        }
         String sql = "select * from t_meta_version t where id = ?";
 
         Map<String, Object> map = queryUnique(sql, tab.getVerId());

--- a/dbus-stream/dbus-stream-common/src/main/java/com/creditease/dbus/stream/common/tools/MessageProcessor.java
+++ b/dbus-stream/dbus-stream-common/src/main/java/com/creditease/dbus/stream/common/tools/MessageProcessor.java
@@ -233,9 +233,10 @@ public abstract class MessageProcessor {
 
     //统计信息并插入到stat的kafka中
     public void statMeter(String schemaName, String tableName, long checkpointMS, long txTimeMS) {
-        StatMessage message = statMap.logMeter(schemaName, tableName, checkpointMS, txTimeMS);
-        sendTableStatInfo (message);
-        message.cleanUp();
+        statMap.logMeter(schemaName, tableName, checkpointMS, txTimeMS).forEach(message -> {
+            sendTableStatInfo(message);
+            message.cleanUp();
+        });
     }
 
     //统计计数

--- a/dbus-stream/dbus-stream-common/src/main/java/com/creditease/dbus/stream/common/tools/TableStatMap.java
+++ b/dbus-stream/dbus-stream-common/src/main/java/com/creditease/dbus/stream/common/tools/TableStatMap.java
@@ -21,10 +21,20 @@
 package com.creditease.dbus.stream.common.tools;
 
 import com.creditease.dbus.commons.StatMessage;
+import com.creditease.dbus.stream.common.Constants;
+import com.creditease.dbus.stream.common.appender.bean.DataTable;
+import com.creditease.dbus.stream.common.appender.bean.TabSchema;
+import com.creditease.dbus.stream.common.appender.cache.ThreadLocalCache;
+import com.creditease.dbus.stream.common.appender.utils.DBFacade;
+import com.creditease.dbus.stream.common.appender.utils.DBFacadeManager;
+import com.creditease.dbus.stream.common.appender.utils.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * key = schemaName.tableName
@@ -33,7 +43,7 @@ public class TableStatMap extends HashMap<String, StatMessage> {
     protected Logger logger = LoggerFactory.getLogger(getClass());
     private String dsName;
 
-    public void initDsName (String dsName) {
+    public void initDsName(String dsName) {
         this.dsName = dsName;
     }
 
@@ -41,32 +51,61 @@ public class TableStatMap extends HashMap<String, StatMessage> {
         return String.format("%s.%s", schemaName, tableName).toLowerCase();
     }
 
-    public void mark(String schemaName, String tableName, long count) {
+    private String getTable(String key) {
+        return key.substring(key.indexOf(".") + 1, key.length());
+    }
 
+    public void mark(String schemaName, String tableName, long count) {
         String key = makeKey(schemaName, tableName);
         StatMessage message = this.get(key);
         if (message == null) {
-            logger.info("mark key:{}",key);
-            return;
+            //处理table regex
+            //同时这样处理不需要先有checkpoint,有数据即可加入,一次checkpoint即将数据shuffle
+            try {
+                //这里没有使用ThreadLocal.get CacheNames.DATA_TABLES, 保证mark的表一定可以加入到statMap,这对统计数据量是有好处的，否则可能漏掉一部分统计量
+                DBFacade db = DBFacadeManager.getDbFacade();
+                TabSchema s = db.queryDataSchema(Utils.getDatasource().getId(), schemaName);
+                List<DataTable> tables = db.queryDataTables(s.getId());
+                DataTable dt = tables.stream().filter(t -> tableName.matches(t.getPhysicalTableRegex()))
+                        .findFirst().orElse(null);
+                if (dt != null) {
+                    message = new StatMessage(dsName, schemaName, tableName, StatMessage.DISPATCH_TYPE);
+                    this.put(key, message);
+                    logger.info("[dispatcher] add new StatMessage for {}", key);
+                } else {
+                    logger.info("mark key:{}", key);
+                    return;
+                }
+            } catch (Exception e) {
+                logger.error("[dispatcher] Query data table error {}", e);
+                return;
+            }
         }
         //count++
         message.addCount(count);
     }
 
-    public StatMessage logMeter(String schemaName, String tableName, long checkpointMS, long txTimeMS) {
-
+    public List<StatMessage> logMeter(String schemaName, String tableName, long checkpointMS, long txTimeMS) {
+        //对模板表进行输出的时候,处理正则表。正则表是没有checkpoint的，需要依靠模板表
         String key = makeKey(schemaName, tableName);
-        StatMessage message = this.get(key);
-        if (message == null) {
-            message = new StatMessage(dsName, schemaName, tableName, StatMessage.DISPATCH_TYPE);
-            logger.info("logMeter put key:{}",key);
-            this.put(key, message);
+        DataTable t = ThreadLocalCache.get(Constants.CacheNames.DATA_TABLES, key);
+        List<StatMessage> msgs = null;
+        if (t != null) {
+            msgs = entrySet().stream().filter(e -> getTable(e.getKey()).matches(t.getPhysicalTableRegex()))
+                    .map(Entry::getValue).collect(Collectors.toList());
         }
+        if (msgs == null || msgs.isEmpty()) {
+            StatMessage message = new StatMessage(dsName, schemaName, tableName, StatMessage.DISPATCH_TYPE);
+            logger.info("logMeter put key:{}", key);
+            this.put(key, message);
+            msgs = Collections.singletonList(message);
+        }
+        msgs.forEach(m -> {
+            m.setCheckpointMS(checkpointMS);
+            m.setTxTimeMS(txTimeMS);
+            m.setLocalMS(System.currentTimeMillis());
+        });
 
-        message.setCheckpointMS(checkpointMS);
-        message.setTxTimeMS(txTimeMS);
-        message.setLocalMS(System.currentTimeMillis());
-
-        return message;
+        return msgs;
     }
 }


### PR DESCRIPTION
1. 处理对表名正则的支持，在分表情况下支持增量合并
2. 修改点:appender阶段的spout中的dataFilter, 这里对拉取到的table进行regex匹配，保证表正则数据不被过滤。
3. 修改点:appender阶段的appender bolt中，判断metaVersion时，也能通过正则获取
4. 修改点:dispatcher阶段的mark/log meter，这里也是进行了正则匹配，保证统计信息正确
5. appender阶段中的appdender bolt中对emit了模板表，后续也就是都使用了了模板表，所以后面应该不需要做正则改动了。
6. 因为5,所以kakfa中的统计信息APPENDER_TYPE,统计量合并了。DISPATCHER_TYPE才能拿到各个正则表的统计情况
Resolve:#31 